### PR TITLE
Fix SystemError on python 3.10

### DIFF
--- a/src/pycryptonight.c
+++ b/src/pycryptonight.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "pycryptonight.h"


### PR DESCRIPTION
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats